### PR TITLE
Adding the template loader to returned Origins 

### DIFF
--- a/apptemplates/__init__.py
+++ b/apptemplates/__init__.py
@@ -42,6 +42,7 @@ if django.VERSION[:2] >= (1, 9):
     def get_template_path(template_dir, template_name, loader=None):
         """Return Origin object with template file path"""
         return Origin(name=join(template_dir, template_name),
+                      template_name=template_name,
                       loader=loader)
 else:
     def get_template_path(template_dir, template_name, loader=None):

--- a/apptemplates/__init__.py
+++ b/apptemplates/__init__.py
@@ -39,11 +39,12 @@ def get_app_template_dir(app_name):
 
 
 if django.VERSION[:2] >= (1, 9):
-    def get_template_path(template_dir, template_name):
+    def get_template_path(template_dir, template_name, loader=None):
         """Return Origin object with template file path"""
-        return Origin(name=join(template_dir, template_name))
+        return Origin(name=join(template_dir, template_name),
+                      loader=loader)
 else:
-    def get_template_path(template_dir, template_name):
+    def get_template_path(template_dir, template_name, loader=None):
         """Return template file path (for Django < 1.9)"""
         return join(template_dir, template_name)
 
@@ -67,6 +68,6 @@ class Loader(FilesystemLoader):
         app_name, template_name = template_name.split(":", 1)
         template_dir = get_app_template_dir(app_name)
         if template_dir:
-            return [get_template_path(template_dir, template_name)]
+            return [get_template_path(template_dir, template_name, self)]
         else:
             return []

--- a/apptemplates/__init__.py
+++ b/apptemplates/__init__.py
@@ -47,6 +47,7 @@ if django.VERSION[:2] >= (1, 9):
 else:
     def get_template_path(template_dir, template_name, loader=None):
         """Return template file path (for Django < 1.9)"""
+        _ = loader  # noqa
         return join(template_dir, template_name)
 
 


### PR DESCRIPTION
This is for compatibility with Django 1.9 + [Django Compressor](https://github.com/django-compressor/django-compressor).

I found that running `python manage.py compress` was throwing an error:

```
Traceback (most recent call last):
  File "manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/Users/Me/.virtualenvs/MyProject/lib/python2.7/site-packages/django/core/management/__init__.py", line 353, in execute_from_command_line
    utility.execute()
  File "/Users/Me/.virtualenvs/MyProject/lib/python2.7/site-packages/django/core/management/__init__.py", line 345, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/Users/Me/.virtualenvs/MyProject/lib/python2.7/site-packages/django/core/management/base.py", line 348, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/Users/Me/.virtualenvs/MyProject/lib/python2.7/site-packages/django/core/management/base.py", line 399, in execute
    output = self.handle(*args, **options)
  File "/Users/Me/.virtualenvs/MyProject/lib/python2.7/site-packages/compressor/management/commands/compress.py", line 286, in handle
    self.compress(sys.stdout, **options)
  File "/Users/Me/.virtualenvs/MyProject/lib/python2.7/site-packages/compressor/management/commands/compress.py", line 181, in compress
    nodes = list(parser.walk_nodes(template))
  File "/Users/Me/.virtualenvs/MyProject/lib/python2.7/site-packages/compressor/offline/django.py", line 150, in walk_nodes
    for node in self.walk_nodes(node, original):
  File "/Users/Me/.virtualenvs/MyProject/lib/python2.7/site-packages/compressor/offline/django.py", line 146, in walk_nodes
    for node in self.get_nodelist(node, original):
  File "/Users/Me/.virtualenvs/MyProject/lib/python2.7/site-packages/compressor/offline/django.py", line 128, in get_nodelist
    return handle_extendsnode(node, block_context=None, original=original)
  File "/Users/Me/.virtualenvs/MyProject/lib/python2.7/site-packages/compressor/offline/django.py", line 34, in handle_extendsnode
    compiled_parent = extendsnode.get_parent(context)
  File "/Users/Me/.virtualenvs/MyProject/lib/python2.7/site-packages/django/template/loader_tags.py", line 148, in get_parent
    return self.find_template(parent, context)
  File "/Users/Me/.virtualenvs/MyProject/lib/python2.7/site-packages/django/template/loader_tags.py", line 128, in find_template
    template_name, skip=history,
  File "/Users/Me/.virtualenvs/MyProject/lib/python2.7/site-packages/django/template/engine.py", line 157, in find_template
    name, template_dirs=dirs, skip=skip,
  File "/Users/Me/.virtualenvs/MyProject/lib/python2.7/site-packages/django/template/loaders/cached.py", line 60, in get_template
    template_name, template_dirs, skip,
  File "/Users/Me/.virtualenvs/MyProject/lib/python2.7/site-packages/django/template/loaders/base.py", line 40, in get_template
    contents = self.get_contents(origin)
  File "/Users/Me/.virtualenvs/MyProject/lib/python2.7/site-packages/django/template/loaders/cached.py", line 28, in get_contents
    return origin.loader.get_contents(origin)
AttributeError: 'NoneType' object has no attribute 'get_contents'
```

The issue was due to the fact that Django compressor calls `origin.loader.get_contents(...)`, but the `Origin` instances being returned by the apptemplates loader didn't bind the loader to the `Origin`.  This fixes that.

All of the tests passed.  I am not sure if Django Compressor is the only use case for this, but it wouldn't surprise me if there were others, since Django's loaders now seem to bind the loader to the `Origin`.

_Update:_
The only tests that fails is a pylint one because one of the arguments is unused in the <Django1.9 compatibility version of the function definition.  I think this is how it should be but don't know how to silence pylint here. Or, if you'd prefer I find a way to somehow use the extra argument, let me know what your stylistic preference is.
