### PR TITLE
Add Django 1.11 to the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,24 @@
 language: python
-python: "3.5"
+dist: trusty
+sudo: required
+python: 3.6
+before_install:
+  - sudo add-apt-repository -y ppa:fkrull/deadsnakes
+  - sudo apt-get -qq update
+  - sudo apt-get -y install python2.6 python3.2
 install: pip install "virtualenv<14.0.0"
 script: python setup.py test
 env:
   # To generate (update) the env list run
   # $ tox -l | sort | xargs -I ITEM echo "  - TOXENV="ITEM
+  # then manually sort the output so that the TOXENV values are in
+  # order by Python version and Django version
   - TOXENV=flake8-py26
   - TOXENV=flake8-py27
   - TOXENV=flake8-py32
   - TOXENV=flake8-py33
   - TOXENV=flake8-py34
   - TOXENV=flake8-py35
-  - TOXENV=pylint-py27-django110
-  - TOXENV=pylint-py35-django110
   - TOXENV=py26-django14
   - TOXENV=py26-django15
   - TOXENV=py26-django16
@@ -23,6 +29,7 @@ env:
   - TOXENV=py27-django18
   - TOXENV=py27-django19
   - TOXENV=py27-django110
+  - TOXENV=py27-django111
   - TOXENV=py32-django15
   - TOXENV=py32-django16
   - TOXENV=py32-django17
@@ -35,6 +42,11 @@ env:
   - TOXENV=py34-django18
   - TOXENV=py34-django19
   - TOXENV=py34-django110
+  - TOXENV=py34-django111
   - TOXENV=py35-django18
   - TOXENV=py35-django19
   - TOXENV=py35-django110
+  - TOXENV=py35-django111
+  - TOXENV=py36-django111
+  - TOXENV=pylint-py27-django111
+  - TOXENV=pylint-py36-django111

--- a/apptemplates/__init__.py
+++ b/apptemplates/__init__.py
@@ -68,5 +68,4 @@ class Loader(FilesystemLoader):
         template_dir = get_app_template_dir(app_name)
         if template_dir:
             return [get_template_path(template_dir, template_name)]
-        else:
-            return []
+        return []

--- a/tox.ini
+++ b/tox.ini
@@ -15,13 +15,13 @@ DJANGO_SETTINGS_MODULE = apptemplates.test.settings
 [tox]
 envlist =
     flake8-py{26,27,32,33,34,35}
-    pylint-py{27,35}-django110
+    pylint-py{27,35}-django111
     py{26,27}-django14
     py{26,27,32,33}-django{15,16}
     py{27,32,33,34}-django17
     py{27,32,33,34,35}-django18
-    py{27,34,35}-django19
-    py{27,34,35}-django110
+    py{27,34,35}-django{19,110}
+    py{27,34,35,36}-django111
 
 [testenv]
 commands =
@@ -35,8 +35,9 @@ deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<2.0
     django{14,15,16}: pytest-django<3.0
-    django{17,18,19,110}: pytest-django
+    django{17,18,19,110,111}: pytest-django
     py{26,32,33}: pytest<3.0
     # virtualenv<14.0.0
 setenv =
@@ -66,14 +67,18 @@ deps = flake8
 commands = flake8
 deps = flake8
 
-[testenv:pylint-py27-django110]
+[testenv:flake8-py36]
+commands = flake8
+deps = flake8
+
+[testenv:pylint-py27-django111]
 commands = pylint --rcfile=tox.ini apptemplates
 deps =
-    django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<2.0
     pylint
 
-[testenv:pylint-py35-django110]
+[testenv:pylint-py36-django111]
 commands = pylint --rcfile=tox.ini apptemplates
 deps =
-    django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<2.0
     pylint


### PR DESCRIPTION
The updates to .travis.yml were made by running the command as directed in the comment.

I corrected a failing `pylint` check by removing an extraneous `else` from the module.